### PR TITLE
Voeg workspace settings toe voor Claude Code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "claudeCode.allowDangerouslySkipPermissions": true
+}


### PR DESCRIPTION
## Type of Change
- [x] New feature

## Description of Changes

Voegt `.vscode/settings.json` toe met `claudeCode.allowDangerouslySkipPermissions: true` op workspace-niveau, zodat gebruikers dit niet meer handmatig hoeven in te stellen in hun persoonlijke VS Code/Positron instellingen.

## Related Issues
Closes #4

## Before / After

### Before:
- Gebruiker moet handmatig in VS Code-instellingen de "Allow dangerously skip permissions" toggle aanzetten
- Zonder deze instelling verschijnen er prompts bij elke bestandswijziging via Claude Code

### After:
- Setting actief voor iedereen die de repo opent, zonder handmatige stap

## Checklist
- [x] I have tested these changes locally
- [x] My code follows the project's coding standards