### PR TITLE
Standaard editor settings en dotfiles ondersteuning

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,12 +5,20 @@
     "vscode": {
       "settings": {
         "terminal.integrated.defaultProfile.linux": "bash",
-        "chat.editing.autoAccept": true
+        "chat.editing.autoAccept": true,
+        "claudeCode.allowDangerouslySkipPermissions": true,
+        "editor.formatOnSave": true,
+        "editor.rulers": [88],
+        "python.defaultInterpreterPath": "/workspaces/python-uv-devcontainer/.venv/bin/python",
+        "[python]": {
+          "editor.defaultFormatter": "charliermarsh.ruff"
+        }
       },
       "extensions": [
         "ms-python.python",
         "ms-python.vscode-pylance",
-        "anthropic.claude-code"
+        "anthropic.claude-code",
+        "charliermarsh.ruff"
       ]
     }
   },

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+  "claudeCode.allowDangerouslySkipPermissions": true,
+  "editor.formatOnSave": true,
+  "editor.rulers": [88],
+  "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
+  "[python]": {
+    "editor.defaultFormatter": "charliermarsh.ruff"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -78,6 +78,21 @@ Zonder deze instelling vraagt de extensie bij elke bestandswijziging om bevestig
 
 > **Snelle fix voor VS Code:** Ga naar VS Code-instellingen → zoek op `Claude` → zet de toggle **"Allow dangerously skip permissions"** aan. Daarna treedt `defaultMode: bypassPermissions` in `.claude/settings.json` in werking en verschijnen er geen prompts meer.
 
+## Persoonlijke instellingen via dotfiles
+
+De container laadt automatisch gedeelde standaard-settings (formatter, linter, Claude Code). Wil je daar je eigen voorkeuren bovenop zetten — zoals shell aliases, git config of editor keybindings — dan kun je een dotfiles repo gebruiken.
+
+**Eenmalig instellen in VS Code of Positron:**
+
+`F1` → **Open User Settings (JSON)** → voeg toe:
+```json
+"dotfiles.repository": "https://github.com/<jouw-gebruikersnaam>/dotfiles"
+```
+
+Bij elke container start kloont de devcontainer jouw dotfiles repo automatisch en voert `install.sh` uit. Je beheert die repo zelf — het raakt deze repo niet.
+
+> Nog geen dotfiles repo? GitHub heeft een [handleiding](https://docs.github.com/en/codespaces/setting-your-user-preferences/personalizing-github-codespaces-for-your-account#dotfiles) om er een aan te maken. De aanpak werkt ook buiten Codespaces in elke devcontainer.
+
 ## Wat zit er in de container?
 
 | Tool | Beschrijving |
@@ -85,6 +100,7 @@ Zonder deze instelling vraagt de extensie bij elke bestandswijziging om bevestig
 | `python` | Python 3.12 |
 | `uv` | Snelle Python package manager |
 | `claude` | Claude Code CLI |
+| `ruff` | Python formatter en linter |
 | CEDA org-skills | Geladen vanuit `cedanl/.github` via `npx skills` |
 
 ## Problemen oplossen


### PR DESCRIPTION
## Type of Change
- [x] New feature
- [x] Documentation update

## Description of Changes

Voegt gedeelde standaard-settings toe voor de hele container én documenteert hoe gebruikers hun persoonlijke instellingen automatisch kunnen inladen via een dotfiles repo.

**Gedeelde standaarden (voor iedereen):**
- `claudeCode.allowDangerouslySkipPermissions: true` — geen prompts meer bij bestandswijzigingen
- `editor.formatOnSave: true` + `ruff` als Python formatter
- `editor.rulers: [88]` — lijnlengte indicator op ruff-standaard
- `python.defaultInterpreterPath` wijst naar de `.venv` in de workspace
- `charliermarsh.ruff` extensie toegevoegd

**Persoonlijke overrides (per gebruiker, optioneel):**
- README sectie toegevoegd: uitleg over dotfiles repo instellen in VS Code/Positron
- Gebruikers configureren eenmalig `dotfiles.repository` in hun lokale settings
- De devcontainer kloont en voert die repo automatisch uit bij elke container start

## Related Issues
Closes #4

## Before / After

### Before:
- Geen gedeelde formatter of linter ingesteld
- `claudeCode.allowDangerouslySkipPermissions` moest handmatig per gebruiker worden aangezet
- Geen mechanisme voor persoonlijke instellingen

### After:
- Ruff formatter actief voor iedereen, formatteert bij opslaan
- Claude Code werkt zonder prompts uit de doos
- Gebruikers kunnen dotfiles repo instellen voor persoonlijke overrides

## Checklist
- [x] I have tested these changes locally
- [x] My code follows the project's coding standards