### PR TITLE
fix: verwijder Foundry vars uit containerEnv voor Positron compatibiliteit

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,8 +5,6 @@
     "ghcr.io/devcontainers/features/github-cli:1": {}
   },
   "containerEnv": {
-    "ANTHROPIC_FOUNDRY_API_KEY": "${localEnv:ANTHROPIC_FOUNDRY_API_KEY}",
-    "ANTHROPIC_FOUNDRY_RESOURCE": "${localEnv:ANTHROPIC_FOUNDRY_RESOURCE}",
     "GITHUB_TOKEN": "${localEnv:GITHUB_TOKEN}"
   },
   "customizations": {
@@ -31,7 +29,7 @@
     }
   },
   "initializeCommand": "touch .devcontainer/.env",
-  "runArgs": ["--env-file", "${localWorkspaceFolder}/.devcontainer/.env"],
+  "runArgs": ["--env-file", ".devcontainer/.env"],
   "postCreateCommand": "bash .devcontainer/post-create.sh",
   "postAttachCommand": "[[ ! -f ~/.claude/.onboarded ]] && bash .devcontainer/onboard.sh || true",
   "forwardPorts": [8501],


### PR DESCRIPTION
## Type of Change
- [x] Bug fix

## Description of Changes

Verwijdert `ANTHROPIC_FOUNDRY_API_KEY` en `ANTHROPIC_FOUNDRY_RESOURCE` uit `containerEnv` in `devcontainer.json`.

Positron resolvet `${localEnv:...}` substitutie niet, waardoor de letterlijke template string als env var waarde wordt gezet. Dit overschrijft de correcte waarden die al via `--env-file .devcontainer/.env` worden geladen, en breekt de Foundry API URL.

## Related Issues

Fixes #11

## Before / After

### Before:
```
API Error: "https://${localEnv:ANTHROPIC_FOUNDRY_RESOURCE}.services.ai.azure.com/anthropic/v1/messages?beta=true" cannot be parsed as a URL
```

### After:
Claude Code start correct op met Foundry credentials uit `.devcontainer/.env`.

## Checklist
- [x] I have tested these changes locally
- [x] My code follows the project's coding standards