### PR TITLE
fix: Codium Devcontainer onboarding en padresolutie

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -33,6 +33,7 @@
   "initializeCommand": "touch .devcontainer/.env",
   "runArgs": ["--env-file", "${localWorkspaceFolder}/.devcontainer/.env"],
   "postCreateCommand": "bash .devcontainer/post-create.sh",
+  "postStartCommand": "[[ ! -f ~/.claude/.onboarded ]] && bash .devcontainer/onboard.sh || true",
   "postAttachCommand": "[[ ! -f ~/.claude/.onboarded ]] && bash .devcontainer/onboard.sh || true",
   "forwardPorts": [8501],
   "remoteUser": "vscode"

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -10,10 +10,11 @@ uv sync
 npx --yes skills add cedanl/.github --skill '*' -a claude-code -a opencode -y --copy -g
 
 # Source .env file on shell startup (fallback for secrets not set on host)
-ENV_FILE="/workspaces/python-uv-devcontainer/.devcontainer/.env"
+ENV_FILE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/.env"
 echo "[ -f \"$ENV_FILE\" ] && set -a && source \"$ENV_FILE\" && set +a" >> ~/.bashrc
 
 # onboard alias for manual re-runs
-echo "alias onboard='bash /workspaces/python-uv-devcontainer/.devcontainer/onboard.sh'" >> ~/.bashrc
+ONBOARD_SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/onboard.sh"
+echo "alias onboard='bash $ONBOARD_SCRIPT'" >> ~/.bashrc
 
 echo "Post-create complete."

--- a/README.md
+++ b/README.md
@@ -21,16 +21,28 @@ Een kant-en-klare ontwikkelomgeving voor Python-projecten met [uv](https://githu
    ```
 3. Klik op **"Reopen in Container"** rechtsonder, of `F1` → **Dev Containers: Reopen in Container**
 
-### Positron
+### Positron / VSCodium
 
-> **Vereiste instelling (experimenteel):** Ga naar Positron-instellingen → zoek op `Dev` → zet **DEV > Containers: Enable** aan. Zonder deze instelling werkt de devcontainer niet.
+Positron en VSCodium ondersteunen de native Dev Containers extensie niet volledig. Gebruik in plaats daarvan de **Codium Devcontainer** extensie — die bouwt de container via Docker en verbindt via SSH.
 
-1. Installeer de extensie **Dev Containers** (`ms-vscode-remote.remote-containers`) via de Positron Extensions-zijbalk
-2. Clone de repo en open de map:
+**Eenmalige setup:**
+
+1. Installeer de benodigde extensies:
    ```bash
-   git clone https://github.com/cedanl/python-uv-devcontainer
+   positron --install-extension DDorch.codium-devcontainer
+   positron --install-extension jeanp413.open-remote-ssh
    ```
-3. Positron detecteert de `.devcontainer/devcontainer.json` automatisch en vraagt of je wilt heropenen in een container.
+2. Installeer de **Claude Code** extensie handmatig via de Extensions-zijbalk (zoek op `anthropic.claude-code` op Open VSX)
+
+**Container starten:**
+
+1. Clone de repo en open de map in Positron
+2. `F1` → **Devcontainer: Open Folder in Devcontainer (SSH)**
+3. Na het bouwen: verbind opnieuw via `F1` → **Devcontainer: Open Folder in Devcontainer (SSH)**
+
+> Bij de eerste verbinding opent een terminal met de onboarding-wizard voor credentials. Zie [Credentials instellen](#credentials-instellen) hieronder.
+
+> **Let op:** `containerEnv` wordt niet ondersteund door Codium Devcontainer. Host shell variabelen worden niet automatisch doorgegeven — gebruik de `.env` methode of de onboarding-wizard.
 
 ### DevPod
 


### PR DESCRIPTION
## Probleem

Twee onafhankelijke bugs die Codium Devcontainer (Positron/VSCodium) breken:

1. **Hardcoded pad** in `post-create.sh` — `/workspaces/python-uv-devcontainer/` werkt niet in omgevingen met een andere workspace path (Codium mount op `/workspace/<naam>`).
2. **Geen onboarding** voor Codium-gebruikers — `postAttachCommand` wordt genegeerd door Codium Devcontainer. Gebruikers starten Claude Code zonder ooit om credentials gevraagd te zijn.

## Waarom PR #12 wrong fix was

PR #12 verwijderde `containerEnv` vars en paste `runArgs` aan. Maar `runArgs` wordt ook genegeerd door Codium Devcontainer — dat lost niets op en breekt VSCode-gebruikers zonder `.env`.

## Wijzigingen

### `devcontainer.json` — `postStartCommand` toegevoegd
`postStartCommand` is de enige runtime hook die zowel VSCode als Codium Devcontainer ondersteunt. De sentinel `~/.claude/.onboarded` voorkomt dubbele run als VSCode toevallig beide hooks uitvoert.

### `post-create.sh` — dynamische padresolutie
Hardcoded paden vervangen door `BASH_SOURCE`-gebaseerde resolutie, exact zoals `onboard.sh` het al correct deed.

## Wat ongewijzigd blijft

- `containerEnv` — blijft voor VSCode-gebruikers die host env vars doorgeven
- `runArgs --env-file` — blijft voor VSCode-gebruikers met `.env`
- `postAttachCommand` — blijft voor VSCode attach flow

Closes #11