### PR TITLE
feat: Pi coding agent + SURF Willma AI-Hub integratie

### DIFF
--- a/.devcontainer/.env.example
+++ b/.devcontainer/.env.example
@@ -21,5 +21,13 @@ AZURE_OPENAI_API_KEY=
 # Note: onboard.sh appends "openai/v1" automatically for the Codex config.
 AZURE_OPENAI_ENDPOINT=
 
+# ── Pi + SURF Willma AI-Hub ──────────────────────────────────────────────────
+# API key voor SURF Willma (beschikbaar via surf.nl voor Nederlandse instellingen).
+WILLMA_API_KEY=
+
+# Endpoint URL van de Willma AI-Hub.
+# Example: https://willma.surf.nl/api/v0
+WILLMA_BASE_URL=
+
 # ── GitHub ───────────────────────────────────────────────────────────────────
 GITHUB_TOKEN=

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -13,8 +13,8 @@ RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - && \
     apt-get install -y --no-install-recommends nodejs && \
     rm -rf /var/lib/apt/lists/*
 
-# Install Codex CLI (OpenAI) globally
-RUN npm install -g @openai/codex
+# Install Codex CLI (OpenAI) and Pi coding agent globally
+RUN npm install -g @openai/codex @earendil-works/pi-coding-agent
 
 # Non-root dev user
 RUN useradd -m vscode

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,7 +9,9 @@
     "ANTHROPIC_FOUNDRY_RESOURCE": "${localEnv:ANTHROPIC_FOUNDRY_RESOURCE}",
     "GITHUB_TOKEN": "${localEnv:GITHUB_TOKEN}",
     "AZURE_OPENAI_API_KEY": "${localEnv:AZURE_OPENAI_API_KEY}",
-    "AZURE_OPENAI_ENDPOINT": "${localEnv:AZURE_OPENAI_ENDPOINT}"
+    "AZURE_OPENAI_ENDPOINT": "${localEnv:AZURE_OPENAI_ENDPOINT}",
+    "WILLMA_API_KEY": "${localEnv:WILLMA_API_KEY}",
+    "WILLMA_BASE_URL": "${localEnv:WILLMA_BASE_URL}"
   },
   "customizations": {
     "vscode": {

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -49,6 +49,10 @@ Gebruik de Codex skill (`/codex`). De deployment in deze omgeving is `gpt-5.2` o
 De sandbox is geconfigureerd via `~/.codex/config.toml` (`approval_policy = "never"`, `sandbox_mode = "danger-full-access"`). Geen extra flags nodig — werkt zowel in CLI als VS Code extension.
 EOF
 
+# Pi (coding agent) — installeer Willma extension
+mkdir -p ~/.pi/agent/extensions
+cp "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/willma-extension.ts" ~/.pi/agent/extensions/willma.ts
+
 # Source .env file on shell startup (fallback for secrets not set on host)
 ENV_FILE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/.env"
 echo "[ -f \"$ENV_FILE\" ] && set -a && source \"$ENV_FILE\" && set +a" >> ~/.bashrc

--- a/.devcontainer/willma-extension.ts
+++ b/.devcontainer/willma-extension.ts
@@ -1,0 +1,42 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+export default async function (pi: ExtensionAPI) {
+  const apiKey = process.env.WILLMA_API_KEY;
+  const baseUrl = process.env.WILLMA_BASE_URL;
+  if (!apiKey || !baseUrl) return;
+
+  let models: any[] = [];
+  try {
+    const resp = await fetch(`${baseUrl}/sequences`, {
+      headers: { "X-API-KEY": apiKey },
+    });
+    if (!resp.ok) return;
+    const data = await resp.json();
+    const list = Array.isArray(data) ? data : (data.data ?? []);
+    models = list
+      .filter((m: any) => m.sequence_type === "text")
+      .map((m: any) => ({
+        id: m.name,
+        name: m.name,
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 128000,
+        maxTokens: 4096,
+      }));
+  } catch {
+    return;
+  }
+
+  if (models.length === 0) return;
+
+  pi.registerProvider("willma", {
+    name: "SURF Willma AI-Hub",
+    baseUrl,
+    api: "openai-completions",
+    apiKey: "WILLMA_API_KEY",
+    headers: { "X-API-KEY": "WILLMA_API_KEY" },
+    compat: { supportsDeveloperRole: false, supportsReasoningEffort: false },
+    models,
+  });
+}


### PR DESCRIPTION
## Summary

- Installeert `@earendil-works/pi-coding-agent` globaal in de container (naast Codex)
- Voegt `willma-extension.ts` toe die bij Pi-opstart modellen live ophaalt van SURF Willma
- Forwardet `WILLMA_API_KEY` en `WILLMA_BASE_URL` via `devcontainer.json`
- Extension skipped netjes als de vars niet ingesteld zijn — niets breekt

## Hoe werkt het

Zodra `WILLMA_API_KEY` en `WILLMA_BASE_URL` zijn ingesteld verschijnen de Willma modellen automatisch in Pi:

```
pi --list-models
# willma    default-text-large
# willma    Qwen 2.5 Coder 32B Instruct AWQ
# willma    ...
```

Gebruik: `pi --provider willma --model default-text-large`

## Test plan

- [ ] Vul `WILLMA_API_KEY` en `WILLMA_BASE_URL` in `.devcontainer/.env`
- [ ] Rebuild devcontainer en verifieer `pi --list-models` toont Willma modellen
- [ ] Test een chat: `pi --provider willma --model default-text-large`
- [ ] Verifieer dat `pi --list-models` leeg is als vars niet ingesteld zijn

🤖 Generated with [Claude Code](https://claude.com/claude-code)