### PR TITLE
feat: persoonlijke config via USER_CONFIG_REPO + Pi skills org-breed

### DIFF
--- a/.devcontainer/.env.example
+++ b/.devcontainer/.env.example
@@ -29,5 +29,16 @@ WILLMA_API_KEY=
 # Example: https://willma.surf.nl/api/v0
 WILLMA_BASE_URL=
 
+# ── Persoonlijke configuratie (optioneel) ────────────────────────────────────
+# Publieke GitHub repo met jouw eigen workflow-uitbreidingen.
+# Format: username/repo  of  https://github.com/username/repo
+#
+# Ondersteunde bestanden in de repo (alles optioneel):
+#   CLAUDE.md          → toegevoegd aan ~/.claude/CLAUDE.md
+#   skills/            → Claude Code skills gekopieerd naar ~/.claude/skills/
+#   pi-extensions/     → Pi extensions gekopieerd naar ~/.pi/agent/extensions/
+#   post-create.sh     → eigen script, draait als laatste stap
+USER_CONFIG_REPO=
+
 # ── GitHub ───────────────────────────────────────────────────────────────────
 GITHUB_TOKEN=

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,8 @@
     "AZURE_OPENAI_API_KEY": "${localEnv:AZURE_OPENAI_API_KEY}",
     "AZURE_OPENAI_ENDPOINT": "${localEnv:AZURE_OPENAI_ENDPOINT}",
     "WILLMA_API_KEY": "${localEnv:WILLMA_API_KEY}",
-    "WILLMA_BASE_URL": "${localEnv:WILLMA_BASE_URL}"
+    "WILLMA_BASE_URL": "${localEnv:WILLMA_BASE_URL}",
+    "USER_CONFIG_REPO": "${localEnv:USER_CONFIG_REPO}"
   },
   "customizations": {
     "vscode": {

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -84,8 +84,9 @@ if [[ -n "${USER_CONFIG_REPO:-}" ]]; then
 
     # Eigen post-create script — draait als laatste
     if [[ -f /tmp/user-config/post-create.sh ]]; then
-      bash /tmp/user-config/post-create.sh
-      echo "  ✔ Eigen post-create.sh uitgevoerd"
+      bash /tmp/user-config/post-create.sh \
+        && echo "  ✔ Eigen post-create.sh uitgevoerd" \
+        || echo "  ✖ Eigen post-create.sh mislukt — container gaat door"
     fi
 
     rm -rf /tmp/user-config

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -7,7 +7,7 @@ echo "Starting post-create setup..."
 uv sync
 
 # Install org-wide Claude/OpenCode skills from cedanl/.github
-npx --yes skills add cedanl/.github --skill '*' -a claude-code -a opencode -y --copy -g
+npx --yes skills add cedanl/.github --skill '*' -a claude-code -a opencode -a pi -y --copy -g
 
 # Install skill-codex (delegates work from Claude to Codex CLI)
 git clone --depth 1 https://github.com/skills-directory/skill-codex.git /tmp/skill-codex \
@@ -52,6 +52,47 @@ EOF
 # Pi (coding agent) — installeer Willma extension
 mkdir -p ~/.pi/agent/extensions
 cp "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/willma-extension.ts" ~/.pi/agent/extensions/willma.ts
+
+# Gebruiker-specifieke configuratie (optioneel)
+# Stel USER_CONFIG_REPO in in .devcontainer/.env — zie .env.example voor de repo-structuur.
+if [[ -n "${USER_CONFIG_REPO:-}" ]]; then
+  REPO_URL="${USER_CONFIG_REPO}"
+  [[ "$REPO_URL" != https://* ]] && REPO_URL="https://github.com/${REPO_URL}"
+  echo "Gebruikersconfig toepassen van ${REPO_URL}..."
+
+  if git clone --depth 1 "$REPO_URL" /tmp/user-config 2>/dev/null; then
+    # CLAUDE.md — toegevoegd aan globale Claude instructies
+    if [[ -f /tmp/user-config/CLAUDE.md ]]; then
+      echo "" >> ~/.claude/CLAUDE.md
+      cat /tmp/user-config/CLAUDE.md >> ~/.claude/CLAUDE.md
+      echo "  ✔ CLAUDE.md toegevoegd"
+    fi
+
+    # Claude skills
+    if [[ -d /tmp/user-config/skills ]]; then
+      mkdir -p ~/.claude/skills
+      cp -r /tmp/user-config/skills/. ~/.claude/skills/
+      echo "  ✔ Claude skills gekopieerd"
+    fi
+
+    # Pi extensions
+    if [[ -d /tmp/user-config/pi-extensions ]]; then
+      mkdir -p ~/.pi/agent/extensions
+      cp -r /tmp/user-config/pi-extensions/. ~/.pi/agent/extensions/
+      echo "  ✔ Pi extensions gekopieerd"
+    fi
+
+    # Eigen post-create script — draait als laatste
+    if [[ -f /tmp/user-config/post-create.sh ]]; then
+      bash /tmp/user-config/post-create.sh
+      echo "  ✔ Eigen post-create.sh uitgevoerd"
+    fi
+
+    rm -rf /tmp/user-config
+  else
+    echo "  ✖ Kon USER_CONFIG_REPO niet clonen: ${REPO_URL} — overgeslagen"
+  fi
+fi
 
 # Source .env file on shell startup (fallback for secrets not set on host)
 ENV_FILE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/.env"


### PR DESCRIPTION
## Summary

- Voegt `USER_CONFIG_REPO` toe: gebruikers kunnen een publieke GitHub repo opgeven met hun eigen workflow-uitbreidingen
- Org-brede skills worden nu ook voor Pi geïnstalleerd (`-a pi` aan `skills add cedanl/.github`)

## USER_CONFIG_REPO structuur

```
jouw-config-repo/
├── CLAUDE.md          → toegevoegd aan ~/.claude/CLAUDE.md
├── skills/            → Claude Code skills → ~/.claude/skills/
├── pi-extensions/     → Pi extensions → ~/.pi/agent/extensions/
└── post-create.sh     → eigen script, draait als laatste stap
```

Alles optioneel — ontbrekende bestanden worden overgeslagen.

## Test plan

- [ ] Stel `USER_CONFIG_REPO=username/repo` in `.devcontainer/.env`
- [ ] Rebuild container — verifieer dat bestanden correct worden toegepast
- [ ] Test met lege repo — verifieer dat container normaal opstart
- [ ] Verifieer org-skills ook in Pi beschikbaar zijn

🤖 Generated with [Claude Code](https://claude.com/claude-code)