### PR TITLE
feat: context-mode integratie

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -13,8 +13,8 @@ RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - && \
     apt-get install -y --no-install-recommends nodejs && \
     rm -rf /var/lib/apt/lists/*
 
-# Install Codex CLI (OpenAI) and Pi coding agent globally
-RUN npm install -g @openai/codex @earendil-works/pi-coding-agent
+# Install Codex CLI (OpenAI), Pi coding agent, and context-mode globally
+RUN npm install -g @openai/codex @earendil-works/pi-coding-agent context-mode
 
 # Non-root dev user
 RUN useradd -m vscode

--- a/.devcontainer/codex-config.toml.template
+++ b/.devcontainer/codex-config.toml.template
@@ -12,3 +12,9 @@ name = "Azure OpenAI"
 base_url = "${AZURE_OPENAI_BASE_URL}"
 env_key = "AZURE_OPENAI_API_KEY"
 wire_api = "responses"
+
+[features]
+hooks = true
+
+[mcp_servers.context-mode]
+command = "context-mode"

--- a/.devcontainer/context-mode-codex-hooks.json
+++ b/.devcontainer/context-mode-codex-hooks.json
@@ -1,0 +1,47 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "local_shell|shell|shell_command|exec_command|container.exec|functions\\.exec_command|Bash|Shell|apply_patch|functions\\.apply_patch|Edit|Write|grep_files|ctx_execute|ctx_execute_file|ctx_batch_execute|ctx_fetch_and_index|ctx_search|ctx_index|mcp__.*__ctx_execute|mcp__.*__ctx_execute_file|mcp__.*__ctx_batch_execute|mcp__.*__ctx_fetch_and_index|mcp__.*__ctx_search|mcp__.*__ctx_index",
+        "hooks": [
+          { "type": "command", "command": "context-mode hook codex pretooluse" }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "hooks": [
+          { "type": "command", "command": "context-mode hook codex posttooluse" }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          { "type": "command", "command": "context-mode hook codex sessionstart" }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "hooks": [
+          { "type": "command", "command": "context-mode hook codex precompact" }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          { "type": "command", "command": "context-mode hook codex userpromptsubmit" }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          { "type": "command", "command": "context-mode hook codex stop" }
+        ]
+      }
+    ]
+  }
+}

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -53,6 +53,55 @@ EOF
 mkdir -p ~/.pi/agent/extensions
 cp "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/willma-extension.ts" ~/.pi/agent/extensions/willma.ts
 
+# context-mode — MCP + hooks voor Claude Code, Codex en Pi
+CM_ROOT=$(node -e "console.log(require.resolve('context-mode/package.json').replace('/package.json',''))" 2>/dev/null || true)
+if [[ -n "$CM_ROOT" ]]; then
+  # Claude Code: MCP server + hooks via settings.json
+  python3 - <<PYEOF
+import json, os
+
+settings_path = os.path.expanduser('~/.claude/settings.json')
+cm_root = "$CM_ROOT"
+
+settings = {}
+if os.path.exists(settings_path):
+    with open(settings_path) as f:
+        settings = json.load(f)
+
+settings.setdefault('mcpServers', {})['context-mode'] = {'command': 'context-mode', 'args': []}
+
+hooks = settings.setdefault('hooks', {})
+
+def add_hook(event, matcher, cmd):
+    entries = hooks.setdefault(event, [])
+    if not any('context-mode' in str(e) and e.get('matcher', '') == matcher for e in entries):
+        entries.append({'matcher': matcher, 'hooks': [{'type': 'command', 'command': cmd}]})
+
+add_hook('PostToolUse',
+    'Bash|Read|Write|Edit|NotebookEdit|Glob|Grep|TodoWrite|TaskCreate|TaskUpdate|EnterPlanMode|ExitPlanMode|Skill|Agent|AskUserQuestion|EnterWorktree|mcp__',
+    f'node "{cm_root}/hooks/posttooluse.mjs"')
+add_hook('PreCompact', '', f'node "{cm_root}/hooks/precompact.mjs"')
+for matcher in ['Bash', 'WebFetch', 'Read', 'Grep']:
+    add_hook('PreToolUse', matcher, f'node "{cm_root}/hooks/pretooluse.mjs"')
+add_hook('UserPromptSubmit', '', f'node "{cm_root}/hooks/userpromptsubmit.mjs"')
+add_hook('SessionStart', '', f'node "{cm_root}/hooks/sessionstart.mjs"')
+
+os.makedirs(os.path.dirname(settings_path), exist_ok=True)
+with open(settings_path, 'w') as f:
+    json.dump(settings, f, indent=2)
+print('  ✔ Claude Code: context-mode MCP + hooks geconfigureerd')
+PYEOF
+
+  # Pi: symlink zodat relatieve import in index.ts naar CM_ROOT/build/ verwijst
+  mkdir -p ~/.pi/agent/extensions
+  ln -sf "${CM_ROOT}/.pi/extensions/context-mode" ~/.pi/agent/extensions/context-mode
+  echo "  ✔ Pi: context-mode extension geïnstalleerd"
+
+  # Codex: hooks
+  cp "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/context-mode-codex-hooks.json" ~/.codex/hooks.json
+  echo "  ✔ Codex: context-mode hooks geconfigureerd"
+fi
+
 # Gebruiker-specifieke configuratie (optioneel)
 # Stel USER_CONFIG_REPO in in .devcontainer/.env — zie .env.example voor de repo-structuur.
 if [[ -n "${USER_CONFIG_REPO:-}" ]]; then


### PR DESCRIPTION
## Summary

- Installeert `context-mode` npm-pakket globaal in de container naast Codex CLI en Pi
- Configureert context-mode als MCP-server + hooks voor **Claude Code** (`~/.claude/settings.json`) via Python in post-create.sh
- Voegt hooks toe voor **Codex CLI** via een statisch `context-mode-codex-hooks.json` bestand (gekopieerd naar `~/.codex/hooks.json`)
- Installeert de **Pi extension** als symlink vanuit de globale npm-installatie, zodat de relatieve import in `index.ts` naar de juiste `build/` map verwijst
- Voegt `[features] hooks = true` en `[mcp_servers.context-mode]` toe aan `codex-config.toml.template`

## Test plan

- [ ] Container bouwen en controleren dat `context-mode` beschikbaar is (`context-mode --version`)
- [ ] `~/.claude/settings.json` bevat `mcpServers.context-mode` en de hooks-entries
- [ ] `~/.codex/hooks.json` bestaat en heeft de context-mode hook-commands
- [ ] `~/.pi/agent/extensions/context-mode` is een symlink naar de globale npm-installatie
- [ ] Claude Code sessie starten: MCP-server `context-mode` listed in `/mcp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)